### PR TITLE
Chunk count overflow on large data transfer

### DIFF
--- a/src/ProcessSupervisor.php
+++ b/src/ProcessSupervisor.php
@@ -377,7 +377,12 @@ class ProcessSupervisor
         }
 
         $this->client->selectWrite(1);
-        $this->client->write($serializedInstruction);
+        
+        $packet = $serializedInstruction . chr(0);
+        $packetSentByteCount = 0;
+        while ($packetSentByteCount < strlen($packet)) {
+            $packetSentByteCount += $this->client->write(substr($packet, $packetSentByteCount));
+        }
 
         $value = $this->readNextProcessValue($instructionShouldBeLogged);
 

--- a/src/node-process/Connection.js
+++ b/src/node-process/Connection.js
@@ -43,10 +43,16 @@ class Connection extends EventEmitter
     {
         socket.setEncoding('utf8');
 
+        let buffer = '';
         socket.on('data', data => {
             this.emit('activity');
 
-            this.handleSocketData(data);
+            buffer += data;
+            if (buffer.endsWith("\0")) {
+                buffer = buffer.slice(0, -1);
+                this.handleSocketData('');
+                buffer = '';
+            }
         });
 
         return socket;

--- a/src/node-process/Connection.js
+++ b/src/node-process/Connection.js
@@ -50,7 +50,7 @@ class Connection extends EventEmitter
             buffer += data;
             if (buffer.endsWith("\0")) {
                 buffer = buffer.slice(0, -1);
-                this.handleSocketData('');
+                this.handleSocketData(buffer);
                 buffer = '';
             }
         });

--- a/src/node-process/Connection.js
+++ b/src/node-process/Connection.js
@@ -109,9 +109,9 @@ class Connection extends EventEmitter
             const chunk = payload.substr(i * bodySize, bodySize);
 
             let chunksLeft = String(chunkCount - 1 - i);
-            chunksLeft = chunksLeft.padStart(Connection.SOCKET_HEADER_SIZE - 1, '0');
+            chunksLeft = chunksLeft.padStart(Connection.SOCKET_HEADER_SIZE, '0');
 
-            this.socket.write(`${chunksLeft}:${chunk}`);
+            this.socket.write(`${chunksLeft}${chunk}`);
         }
     }
 


### PR DESCRIPTION
When trying to get a large result of `evaluate`, if the result exceeds 10Mb, it will not be parsed, instead returning `null` without any warnings.
Example of such result is collecting all of images on the web page and returning as an array of base64-encoded image contents.

Digging down, it appeared that initial chucks of data arrive, but subsequent are rejected. 

Each chuck starts with 5-byte count of next chunks
https://github.com/zoonru/rialto/blob/4c59d7b0e1063ba5509bffa87347861b2cb98276/src/ProcessSupervisor.php#L411-L412

With logging added on a large result `chunkLeft`s were: 15542, F1554 (to int -> 0), and then third is never read.

This is how it is actually packed:
https://github.com/zoonru/rialto/blob/4c59d7b0e1063ba5509bffa87347861b2cb98276/src/node-process/Connection.js#L111-L114

So instead of 5-char number, it is 4-char + ":". But this ":" separator is never used.

Solution is to remove the separator and use all 5 bytes, resulting in 99999 max chunks (~100mb). 