### PR TITLE
Fix socket chunk transmission issue for large transfers in writeToSocket function

### DIFF
--- a/src/node-process/Connection.js
+++ b/src/node-process/Connection.js
@@ -107,18 +107,27 @@ class Connection extends EventEmitter
     writeToSocket(str)
     {
         const payload = Buffer.from(str).toString('base64');
-
         const bodySize = Connection.SOCKET_PACKET_SIZE - Connection.SOCKET_HEADER_SIZE,
             chunkCount = Math.ceil(payload.length / bodySize);
 
-        for (let i = 0 ; i < chunkCount ; i++) {
-            const chunk = payload.substr(i * bodySize, bodySize);
+        let i = 0;
 
-            let chunksLeft = String(chunkCount - 1 - i);
-            chunksLeft = chunksLeft.padStart(Connection.SOCKET_HEADER_SIZE, '0');
+        const sendChunk = () => {
+            if (i < chunkCount) {
+                const chunk = payload.slice(i * bodySize, (i + 1) * bodySize);
+                let chunksLeft = String(chunkCount - 1 - i);
+                chunksLeft = chunksLeft.padStart(Connection.SOCKET_HEADER_SIZE, '0');
 
-            this.socket.write(`${chunksLeft}${chunk}`);
-        }
+                this.socket.write(`${chunksLeft}${chunk}`);
+                console.log(`Sending chunk ${i + 1}/${chunkCount}`);
+                i++;
+
+                // Schedule the next chunk to be sent immediately after the current execution
+                setImmediate(sendChunk);
+            }
+        };
+
+        sendChunk();
     }
 
     /**


### PR DESCRIPTION
### Description
This PR addresses an issue related to large socket transfers in the writeToSocket function, as described in [#17](https://github.com/zoonru/puphpeteer/issues/17).

The original implementation caused the socket to crash when handling many chunks, preventing the successful transmission of all data. This issue arises because the loop that manages the chunked transfer executes too quickly.

### Fix:
To resolve the issue, the code was modified to use setImmediate() to control the flow of chunk transmission. This ensures that chunks are sent sequentially without overwhelming the socket, allowing for successful large data transfers.

### Impact:
This fix improves the handling of large socket transfers and prevents crashes during transmission.