### PR TITLE
fix: fixed the issue that led to incomplete data being read from socket

### DIFF
--- a/src/ProcessSupervisor.php
+++ b/src/ProcessSupervisor.php
@@ -26,18 +26,11 @@ class ProcessSupervisor
     protected const PROCESS_TERMINATION_DELAY = 100;
 
     /**
-     * The size of a packet sent through the sockets (in bytes).
+     * The size of the first chunk of a packet sent through the sockets (in bytes).
      *
      * @var int
      */
-    protected const SOCKET_PACKET_SIZE = 1024;
-
-    /**
-     * The size of the header in each packet sent through the sockets (in bytes).
-     *
-     * @var int
-     */
-    protected const SOCKET_HEADER_SIZE = 5;
+    protected const SOCKET_READ_LENGTH_FIRST_CHUNK = 1024;
 
     /**
      * A short period to wait before reading the next chunk (in milliseconds), this avoids the next chunk to be read as
@@ -405,24 +398,27 @@ class ProcessSupervisor
     {
         $readTimeout = $this->options['read_timeout'];
         $payload = '';
+        $payLoadLength = 0;
 
         try {
             $startTimestamp = microtime(true);
 
             do {
                 $this->client->selectRead($readTimeout);
-                $packet = $this->client->read(static::SOCKET_PACKET_SIZE);
+                $packet = $this->client->read($payLoadLength === 0 ? static::SOCKET_READ_LENGTH_FIRST_CHUNK : $payLoadLength - strlen($payload));
 
-                $chunksLeft = (int) substr($packet, 0, static::SOCKET_HEADER_SIZE);
-                $chunk = substr($packet, static::SOCKET_HEADER_SIZE);
+                $payload .= $packet;
 
-                $payload .= $chunk;
+                if ($payLoadLength === 0 && strlen($payload) >= 4) {
+                    $payLoadLength = unpack('N', $payload)[1];
+                    $payload = substr($payload, 4);
+                }
 
-                if ($chunksLeft > 0) {
+                if ($payLoadLength === 0 || $payLoadLength !== strlen($payload)) {
                     // The next chunk might be an empty string if don't wait a short period on slow environments.
                     usleep(self::SOCKET_NEXT_CHUNK_DELAY * 1000);
                 }
-            } while ($chunksLeft > 0);
+            } while ($payLoadLength === 0 || $payLoadLength !== strlen($payload));
         } catch (SocketException $exception) {
             $this->waitForProcessTermination();
             $this->checkProcessStatus();
@@ -441,7 +437,7 @@ class ProcessSupervisor
 
         $this->logProcessStandardStreams();
 
-        ['logs' => $logs, 'value' => $value] = json_decode(base64_decode($payload), true);
+        ['logs' => $logs, 'value' => $value] = json_decode($payload, true);
 
         foreach ($logs ?: [] as $log) {
             $level = (new \ReflectionClass(LogLevel::class))->getConstant($log['level']);

--- a/src/node-process/Connection.js
+++ b/src/node-process/Connection.js
@@ -100,34 +100,17 @@ class Connection extends EventEmitter
     }
 
     /**
-     * Write a string to the socket by slitting it in packets of fixed length.
+     * Write a string to the socket
      *
      * @param  {string} str
      */
     writeToSocket(str)
     {
-        const payload = Buffer.from(str).toString('base64');
-        const bodySize = Connection.SOCKET_PACKET_SIZE - Connection.SOCKET_HEADER_SIZE,
-            chunkCount = Math.ceil(payload.length / bodySize);
+        const payload = Buffer.from(str);
+        const payloadLength = Buffer.alloc(4);
+        payloadLength.writeUInt32BE(payload.length);
 
-        let i = 0;
-
-        const sendChunk = () => {
-            if (i < chunkCount) {
-                const chunk = payload.slice(i * bodySize, (i + 1) * bodySize);
-                let chunksLeft = String(chunkCount - 1 - i);
-                chunksLeft = chunksLeft.padStart(Connection.SOCKET_HEADER_SIZE, '0');
-
-                this.socket.write(`${chunksLeft}${chunk}`);
-                console.log(`Sending chunk ${i + 1}/${chunkCount}`);
-                i++;
-
-                // Schedule the next chunk to be sent immediately after the current execution
-                setImmediate(sendChunk);
-            }
-        };
-
-        sendChunk();
+        this.socket.write(Buffer.concat([payloadLength, payload]));
     }
 
     /**
@@ -152,21 +135,5 @@ class Connection extends EventEmitter
         return DataSerializer.serializeError(error);
     }
 }
-
-/**
- * The size of a packet sent through the sockets.
- *
- * @constant
- * @type {number}
-*/
-Connection.SOCKET_PACKET_SIZE = 1024;
-
-/**
- * The size of the header in each packet sent through the sockets.
- *
- * @constant
- * @type {number}
- */
-Connection.SOCKET_HEADER_SIZE = 5;
 
 module.exports = Connection;


### PR DESCRIPTION
### Issue
Data chunks were incompletely read from a socket as `socket_read` can return less bytes than expected(1024). This led to corrupt data.

### Fix
1) Prefixing payload with its length ensures that the full data was received on the other end.
2) Removed encoding data to base64 since reading/writing from/to socket is binary-safe.
3) Removed chunking as net.socket.write can handle large data transfers.